### PR TITLE
Use int* instead of size_t* to retreive array sizes

### DIFF
--- a/drmaa_utils/drmaa.h
+++ b/drmaa_utils/drmaa.h
@@ -312,9 +312,9 @@ int drmaa_get_next_attr_value( drmaa_attr_values_t* values,
 	char *value, size_t value_len );
 int drmaa_get_next_job_id( drmaa_job_ids_t* values,
 	char *value, size_t value_len );
-int drmaa_get_num_attr_names( drmaa_attr_names_t* values, size_t *size );
-int drmaa_get_num_attr_values(drmaa_attr_values_t* values, size_t *size );
-int drmaa_get_num_job_ids( drmaa_job_ids_t* values, size_t *size );
+int drmaa_get_num_attr_names( drmaa_attr_names_t* values, int *size );
+int drmaa_get_num_attr_values(drmaa_attr_values_t* values, int *size );
+int drmaa_get_num_job_ids( drmaa_job_ids_t* values, int *size );
 void drmaa_release_attr_names( drmaa_attr_names_t* values );
 void drmaa_release_attr_values( drmaa_attr_values_t* values );
 void drmaa_release_job_ids( drmaa_job_ids_t* values );

--- a/drmaa_utils/drmaa_base.c
+++ b/drmaa_utils/drmaa_base.c
@@ -277,7 +277,7 @@ int drmaa_get_next_##name( type *values, char *value, size_t value_len ) \
 	strlcpy( value, iter->next(iter), value_len ); \
 	DRMAA_API_END \
 } \
-int drmaa_get_num_##name##s( type *values, size_t *size ) \
+int drmaa_get_num_##name##s( type *values, int *size ) \
 { \
 	char error_diagnosis[1]; \
 	size_t error_diag_len = sizeof(error_diagnosis); \


### PR DESCRIPTION
On all bindings manual pages I could find ([example](http://gridscheduler.sourceforge.net/htmlman/htmlman3/drmaa_attributes.html) ) the drmaa_get_num_xxx functions uses a int * to store their result.

On some (most?) platforms, int * and size_t are not compatibles.
The [go binding](https://github.com/dgruber/drmaa), for one, fails to build because of this.


