### PR TITLE
Prevent potential NULL dereference in drmaa_wait()

### DIFF
--- a/drmaa_utils/drmaa_base.c
+++ b/drmaa_utils/drmaa_base.c
@@ -517,7 +517,15 @@ drmaa_wait(
 				session, job_id, drmaa_timeout_time(timeout, &ts),
 				stat, (fsd_iter_t**)rusage
 				);
-		strlcpy( job_id_out, result_job_id, job_id_out_len );
+		/* result_job_id might be NULL if wait_for_any_job() timed out */
+		if( result_job_id != NULL )
+		  {
+			strlcpy( job_id_out, result_job_id, job_id_out_len );
+		  }
+		else if( job_id_out && job_id_out_len > 0 )
+		  {
+			job_id_out[0] = '\0';
+		  }
 	 }
 	FINALLY
 	 {


### PR DESCRIPTION
In drmaa_wait(), result_job_id is assigned from session->wait(), which calls fsd_drmaa_session_wait(). In the DRMAA_JOB_IDS_SESSION_ANY case, this in turn calls fsd_drmaa_session_wait_for_any_job(), which can return NULL without raising an exception — for example if fsd_strdup() fails due to memory exhaustion.
In this case result_job_id is NULL when strlcpy() is called, causing a segfault.
This was confirmed via a core dump showing result_job_id = 0x0 and _fsd_exc_rc = 0 (indicating normal execution path, no exception raised) in drmaa_wait().
The patch adds a NULL check before the strlcpy() call, leaving job_id_out as an empty string if result_job_id is NULL.

Thanks to Claude for troubleshooting and writing this description.